### PR TITLE
Fix incorrect handling of backslash at end of strings

### DIFF
--- a/sjson.go
+++ b/sjson.go
@@ -100,7 +100,7 @@ func parsePath(path string) (pathResult, error) {
 
 func mustMarshalString(s string) bool {
 	for i := 0; i < len(s); i++ {
-		if s[i] < ' ' || s[i] > 0x7f || s[i] == '"' {
+		if s[i] < ' ' || s[i] > 0x7f || s[i] == '"' || (s[i] == '\\' && i == len(s)-1) {
 			return true
 		}
 	}

--- a/sjson_test.go
+++ b/sjson_test.go
@@ -142,6 +142,7 @@ func TestBasic(t *testing.T) {
 	testRaw(t, setBool, `[true]`, ``, `0`, true)
 	testRaw(t, setBool, `[null]`, ``, `0`, nil)
 	testRaw(t, setString, `{"arr":[1]}`, ``, `arr.-1`, 1)
+	testRaw(t, setString, `{"a":"\\"}`, ``, `a`, "\\")
 }
 
 func TestDelete(t *testing.T) {


### PR DESCRIPTION
Hello, I'm having trouble with backslashes at the end of string values not producing valid JSON. Here's an example that reproduces the issue:

```
package main

import (
	"encoding/json"
	"fmt"

	"github.com/tidwall/sjson"
)

func main() {
	out, err := sjson.SetBytes(nil, "a", "\\")
	if err != nil {
		panic(err)
	}
	fmt.Println(string(out))
	m := make(map[string]interface{})
	err = json.Unmarshal(out, &m)
	if err != nil {
		panic(err)
	}
	fmt.Println(m)
}
```

When run, `json.Unmarshal` returns an error and triggers the panic.

```
{"a":"\"}
panic: unexpected end of JSON input

goroutine 1 [running]:
main.main()
	/home/jds/projects/golang/src/jds/gjsontest/main.go:19 +0x24b
exit status 2
```

I believe the correct JSON output should be `{"a":"\\"}`

This PR fixes this for me and includes the above example as a new test case.

Thanks for the very useful library!