### PR TITLE
Fix for missing escape characters for backslashes

### DIFF
--- a/sjson.go
+++ b/sjson.go
@@ -108,7 +108,7 @@ func parsePath(path string) (pathResult, error) {
 
 func mustMarshalString(s string) bool {
 	for i := 0; i < len(s); i++ {
-		if s[i] < ' ' || s[i] > 0x7f || s[i] == '"' || (s[i] == '\\' && i == len(s)-1) {
+		if s[i] < ' ' || s[i] > 0x7f || s[i] == '"' || s[i] == '\\' {
 			return true
 		}
 	}

--- a/sjson_test.go
+++ b/sjson_test.go
@@ -118,9 +118,17 @@ func TestBasic(t *testing.T) {
 		``,
 		"\\:1.this.4", `4`)
 	testRaw(t, setRaw,
-		`{":\1":{"this":[null,null,null,null,{".HI":4}]}}`,
+		"{\":\u2605\":{\"this\":[null,null,null,null,{\".HI\":4}]}}",
 		``,
-		"\\:\\\\1.this.4.\\.HI", `4`)
+		"\\:\\\u2605.this.4.\\.HI", `4`)
+	testRaw(t, setRaw,
+		`{"host":"\\\\127.0.0.1"}`,
+		``,
+		"host", `"\\\\127.0.0.1"`)
+	testRaw(t, setString,
+		`{"host":"\\\\127.0.0.1"}`,
+		``,
+		"host", `\\127.0.0.1`)
 	testRaw(t, setRaw,
 		`{"app.token":"cde"}`,
 		`{"app.token":"abc"}`,


### PR DESCRIPTION
Hi,

I had a problem with SetBytes where setting a value to a UNC path with the backslashes escaped such as `"\\\\127.0.0.1"` produces a JSON document with missing slashes, i.e. `"\\127.0.0.1"` which once escaped is `\127.0.0.1` This was found by using gjson.GetBytes to grab a UNC path and use sjson.SetBytes to write it to a different JSON document. The result was a different number of backslashes between the original document and new document. I also noticed that if the original value is instead `"\\\\127.0.01\r"` then setBytes produces the correct result.

The fix seems to be to change mustMarshalString so it returns true when a backslash is found as opposed to only if its found at the end of the string. I couldn't think why you would want to marshal the string when the backslash is at the end but not marshal if it appears anywhere else. Please let me know if you can think of a scenario

The change did break a unit test but the unit test seems to be trying to create a field with the name `":\1"` which is not a valid JSON name as the `\` character is an escape character and can only be followed by `"`, `\`, `/`, `b`, `n`, `r`, `t` or `u`.