### PR TITLE
Force string value if path contains ":" at any position

### DIFF
--- a/sjson.go
+++ b/sjson.go
@@ -365,6 +365,8 @@ func appendRawPaths(buf []byte, jstr string, paths []pathResult, raw string,
 		if !numeric {
 			if paths[0].part == "-1" && !paths[0].force {
 				appendit = true
+			} else if paths[0].force {
+				appendit = true
 			} else {
 				return nil, &errorType{
 					"cannot set array element for non-numeric key '" +

--- a/sjson.go
+++ b/sjson.go
@@ -65,6 +65,9 @@ func parsePath(path string) (res pathResult, simple bool) {
 			r.more = true
 			return r, true
 		}
+		if path[i] == ':' {
+			r.force = true
+		}
 		if !isSimpleChar(path[i]) {
 			return r, false
 		}

--- a/sjson.go
+++ b/sjson.go
@@ -365,8 +365,6 @@ func appendRawPaths(buf []byte, jstr string, paths []pathResult, raw string,
 		if !numeric {
 			if paths[0].part == "-1" && !paths[0].force {
 				appendit = true
-			} else if paths[0].force {
-				appendit = true
 			} else {
 				return nil, &errorType{
 					"cannot set array element for non-numeric key '" +


### PR DESCRIPTION
The background is that I was trying to assign paths with nested keys containing colons, like this:

```
properties.geo:depictions.sfomuseum:locality = [ 1234 ]
```

Which would trigger the following error: 

```
cannot set array element for non-numeric key 'sfomuseum:locality'
```

This PR add a simple check in `parsePath` to set `r.force=true` if a path contains a ":" at any position rather than just at the start. This changes passes all the tests but I am willing to believe that I am possibly missing an edge case.

